### PR TITLE
feat: allow syncing from git shas

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,14 +62,19 @@ inputs:
     required: false
     type: string
   sync-branch:
+    deprecationMessage: sync-branch has been replaced with sync-tree and now allows git shas.
     description: The repository branch to sync from
     required: false
     type: string
-    default: main
   sync-repository:
     description: The repository to sync from
     required: true
     type: string
+  sync-tree:
+    description: The repository branch or sha to sync from
+    required: false
+    type: string
+    default: main
 
 outputs:
   pull_request_url:

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,9 +19,9 @@ export type Config = {
   prTitle: string;
   prToken?: string;
   syncAuth?: string;
-  syncBranch: string;
   syncPath: string;
   syncRepository: string;
+  syncTree?: string;
   templateVariables: Record<string, string>;
 };
 
@@ -46,9 +46,11 @@ export function getConfig(): Config {
     prTitle: core.getInput("pr-title", { required: true }),
     prToken: core.getInput("pr-token", { required: false }),
     syncAuth: core.getInput("sync-auth", { required: false }),
-    syncBranch: core.getInput("sync-branch", { required: true }),
     syncPath: createTempPath(),
     syncRepository: core.getInput("sync-repository", { required: true }),
+    syncTree:
+      core.getInput("sync-branch", { required: false }) ??
+      core.getInput("sync-tree", { required: true }),
     templateVariables: {},
   };
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -8,16 +8,22 @@ import { Config } from "./config";
 import { getOctokit } from "./octokit";
 
 export async function cloneRepository(config: Config): Promise<void> {
-  const { syncAuth, syncPath, syncRepository, syncBranch } = config;
+  const { syncAuth, syncPath, syncRepository, syncTree } = config;
 
   const tempDirectory = await mkdirP(syncPath);
+
   await exec(
-    `git clone https://${syncAuth}@${syncRepository} --branch ${syncBranch} ${syncPath}`,
+    `git clone https://${syncAuth}@${syncRepository} ${syncPath}`,
     [],
     {
       silent: !core.isDebug(),
     },
   );
+
+  await exec(`git checkout --detach ${syncTree}`, [], {
+    cwd: syncPath,
+    silent: !core.isDebug(),
+  });
 }
 
 export async function configureRepository(config: Config): Promise<void> {


### PR DESCRIPTION
Right now you are only able to sync from branches. This is a problem when trying to test because you want to run sync against a random sha. This fixes that problem. `sync-branch` is now deprecated in favor of `sync-tree` which accepts shas. 